### PR TITLE
Update to @opensearch-project/opensearch 2.2.1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,8 +39,6 @@ export const search = memoizee(
         options,
         AwsSigv4Signer({
           region,
-          // @ts-expect-error: service is missing from type definition;
-          // fixed in https://github.com/opensearch-project/opensearch-js/pull/377
           service,
         })
       )

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@architect/functions": "^5.3.4",
         "@aws-sdk/credential-provider-node": "3.188.0",
-        "@opensearch-project/opensearch": "^2.2.0",
+        "@opensearch-project/opensearch": "^2.2.1",
         "memoizee": "^0.4.15"
       },
       "devDependencies": {
@@ -869,9 +869,9 @@
       }
     },
     "node_modules/@opensearch-project/opensearch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.2.0.tgz",
-      "integrity": "sha512-E0f2Hooruz9y+17AF69oyyruikVMAEr1TxcQBNEQV4aQnI3o0+6CjqZS+t94SCZdWRTuN7HjIIVGbaYCJDpxgA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.2.1.tgz",
+      "integrity": "sha512-8zfQX1acL9eWG+ohIc9nJVT9LSqXCdbVEJs0rCPRtji3XF6ahzsiKmGNTeWLxCPDxWCjAIWq9t95xP3Y5Egi6Q==",
       "dependencies": {
         "aws4": "^1.11.0",
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@architect/functions": "^5.3.4",
     "@aws-sdk/credential-provider-node": "3.188.0",
-    "@opensearch-project/opensearch": "^2.2.0",
+    "@opensearch-project/opensearch": "^2.2.1",
     "memoizee": "^0.4.15"
   },
   "devDependencies": {


### PR DESCRIPTION
Drop workaround for opensearch-project/opensearch-js#377, which has been fixed upstream.